### PR TITLE
add command to generate policy migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.12.x, 1.13.x, 1.15.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:

--- a/cmd/cli/generator/policyMigration.go
+++ b/cmd/cli/generator/policyMigration.go
@@ -86,7 +86,7 @@ var policyMigrationCmd = &cobra.Command{
 		cfg := helpers.LoadConfig()
 		serviceName := cfg.Meta.ServiceName
 
-		if err := ensureMigrationsFileExists(path.Join(rootPath, "./db/policy/(migrations).go"), serviceName); err != nil {
+		if err := ensureMigrationsFileExists(path.Join(rootPath, "./db/policy/0_migrations.go"), serviceName); err != nil {
 			log.Error(err)
 			return
 		}

--- a/cmd/cli/generator/policyMigration.go
+++ b/cmd/cli/generator/policyMigration.go
@@ -118,11 +118,6 @@ func TestPolicyMigrations(t *testing.T) {
 	RunSpecs(t, "Policy Migrations Suite")
 }
 
-var _ = BeforeSuite(func() {
-	amTests.CreateDB()
-
-})
-
 var (
 	DB dbPkg.DB
 )
@@ -164,7 +159,8 @@ import (
 
 var _ = Describe("%s", func() {
 	migrationVersion := int64(%s)
-	migration := dbPolicy.Migrations[migrationVersion]
+	migration, ok := dbPolicy.Migrations[migrationVersion]
+	Expect(ok).To(BeTrue())
 	Expect(migration.Version).To(Equal(migrationVersion))
 
 	Context("Up", func() {

--- a/cmd/cli/generator/policyMigration.go
+++ b/cmd/cli/generator/policyMigration.go
@@ -1,0 +1,104 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/nrfta/go-log"
+	"github.com/nrfta/go-tiger/helpers"
+	"github.com/spf13/cobra"
+)
+
+const mainPolicyFileContent = `package dbPolicy
+
+import (
+  policyMigration "github.com/nrfta/go-platform-security-policy-migration/pkg/policy_migration"
+)
+
+var (
+  migrations = make(policyMigration.Migrations)
+)
+
+func MigrateUp() error {
+	op := policyMigration.NewOperation(migrations, config.Config.Security)
+	return op.Up()
+}
+
+func MigrateDown() error {
+	op := policyMigration.NewOperation(migrations, config.Config.Security)
+	return op.Down()
+}
+`
+
+var policyMigrationCmd = &cobra.Command{
+	Use:   "policyMigration [platform security policy version] [policyID,policyID,...] [description]",
+	Short: "Generates a security policy migration file",
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		t := time.Now()
+		timestamp := t.Format("20060102150405")
+		policyIDs := strings.Split(args[1], ",")
+		policyIDsStr := `"` + strings.Join(policyIDs, `", "`) + `"`
+		description := strings.ReplaceAll(args[2], " ", "_")
+		name := args[1] + "_" + description
+		baseFileName := path.Join(helpers.FindRootPath(), "./db/policy/"+timestamp+"_"+name)
+
+		if err := ensureMigrationsFileExists(path.Join(helpers.FindRootPath(), "./db/policy/(migrations).go")); err != nil {
+			log.Error(err)
+			return
+		}
+
+		content := fmt.Sprintf(`package dbPolicy
+
+import (
+	"errors"
+
+  policyMigration "github.com/nrfta/go-platform-security-policy-migration/pkg/policy_migration"
+)
+
+func init() {
+	migrations[%s] = &policyMigration.Migration{
+		Version:       %s,
+		PolicyVersion: "%s",
+		PolicyIDs:     []string{%s},
+		Description:   "%s",
+		Up:            migration%sUp,
+		Down:          migration%sDown,
+	}
+}
+
+func migration%sUp(policyVersion string) error {
+	// migrate up implementation
+	return errors.New("not implemented")
+}
+
+func migration%sDown(policyVersion string) error {
+	// migrate up implementation
+	return errors.New("not implemented")
+}
+`, timestamp, timestamp, args[0], policyIDsStr, args[2], timestamp, timestamp, timestamp, timestamp)
+
+		err := writeFile(baseFileName+".go", content)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		fmt.Println(baseFileName + ".go created")
+	},
+}
+
+func init() {
+	GenerateCmd.AddCommand(policyMigrationCmd)
+}
+
+func ensureMigrationsFileExists(path string) error {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return writeFile(path, mainPolicyFileContent)
+	}
+	return nil
+}

--- a/cmd/cli/generator/policyMigration.go
+++ b/cmd/cli/generator/policyMigration.go
@@ -165,12 +165,16 @@ var _ = Describe("%s", func() {
 
 	Context("Up", func() {
 		It("should migrate up and apply correct policies", func() {
+			// err := migration.Up(migration.PolicyVersion)
+			// Expect(err).To(BeNil())
 			Expect(false).To(BeTrue(), "policy migration tests are required")
 		})
 	})
 
 	Context("Down", func() {
 		It("should migrate down and revoke correct policies", func() {
+			// err := migration.Down(migration.PolicyVersion)
+			// Expect(err).To(BeNil())
 			Expect(false).To(BeTrue(), "policy migration tests are required")
 		})
 	})


### PR DESCRIPTION
```
Usage:
  tiger generate policyMigration [platform-security-policy-version] [policyID,policyID,...] [description]
```

For example: 

```shell
tiger generate policyMigration v0.0.13 ac-3 "User can update their own account"`
```