### PR TITLE
fix: use UTC for migration timestamp

### DIFF
--- a/cmd/cli/generator/migration.go
+++ b/cmd/cli/generator/migration.go
@@ -16,7 +16,7 @@ var migrationCmd = &cobra.Command{
 	Short: "Generates a migration file",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		t := time.Now()
+		t := time.Now().UTC()
 		timestamp := t.Format("20060102150405")
 		baseFileName := path.Join(helpers.FindRootPath(), "./db/migrations/"+timestamp+"_"+args[0])
 


### PR DESCRIPTION
## Linear Ticket Link

N/A

## Description

Updated migration task to use UTC instead of local time to remove time conflicts.

## How did you test the changes?

- Local build and ran task

## Dependencies

N/A
