### PR TITLE
Update air_template to allow for better debugging

### DIFF
--- a/cmd/cli/start/air_template.go
+++ b/cmd/cli/start/air_template.go
@@ -6,7 +6,7 @@ func defaultAirConfig(appName string) string {
 	template := `
 [build]
   bin = "./bin/%s"
-  cmd = "go build -o ./bin/%s ."
+  cmd = "go build -gcflags=all=\"-N -l\" -o ./bin/%s ."
   exclude_dir = ["bin", "tests", "templates", "scripts", "db", "build", "tmp"]
 	exclude_regex = ["_test.go"]
   kill_delay = 500

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/nrfta/go-tiger
 
-go 1.22
-toolchain go1.22.10
+go 1.22.6
+
+toolchain go1.24.3
 
 require (
 	github.com/air-verse/air v1.52.3


### PR DESCRIPTION
## Description

Adds `-gcflags=all="-N -l"` to air cmd to disable inlining and optimizations that can interfere with debugging.

https://github.com/golang/vscode-go/blob/master/docs/debugging.md#attach

## How did you test the changes?

N/A

## Dependencies

N/A