### PR TITLE
chore: update air options after upgrade

### DIFF
--- a/cmd/cli/start/air_template.go
+++ b/cmd/cli/start/air_template.go
@@ -7,9 +7,13 @@ func defaultAirConfig(appName string) string {
 [build]
   bin = "./bin/%s"
   cmd = "go build -o ./bin/%s ."
-  exclude_dir = ["bin", "tests", "templates", "scripts", "db/migrations", "pkg/schemas"]
+  exclude_dir = ["bin", "tests", "templates", "scripts", "db", "build", "tmp"]
+	exclude_regex = ["_test.go"]
   kill_delay = 500
   send_interrupt = true
+	stop_on_error = true
+[misc]
+  clean_on_exit = true
 `
 
 	return fmt.Sprintf(template, appName, appName)


### PR DESCRIPTION

## Description

Last PR updated air, a new option needed to be added in order to it stop the server on error.

## How did you test the changes?

Locally

## Dependencies

None
